### PR TITLE
Remote launch now works - FIXED (tested from vizzy-laptop)

### DIFF
--- a/vizzy_demos/launch/aha_internal_meeting_demo.launch
+++ b/vizzy_demos/launch/aha_internal_meeting_demo.launch
@@ -8,7 +8,7 @@
   <!-- robot configuration parameters -->
   <arg name="vizzy_machine_name" default="vizzy-desktop"/>
   <arg name="vizzy_machine_address" default="10.10.1.80"/>
-  <arg name="env-loader" default="/home/vizzy/catkin_workspace/devel/env.sh"/>
+  <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
   <machine name="$(arg vizzy_machine_name)" address="$(arg vizzy_machine_address)" env-loader="$(arg env-loader)" user="vizzy"/>
 
   <!-- simulation parameters and robot configuration parameters -->
@@ -52,6 +52,7 @@
   	<arg name="env-loader" value="$(arg env-loader)"/>
   	<arg name="ros_cameras_on" value="$(arg ros_cameras_on)"/>
   	<arg name="map_file" value="$(arg map_file)" />
+    <arg name="define_machine" value="false"/>
 	<arg name="frame_rate" value="15.0" />
 	<arg name="left_camera_file" value="left_camera_params.yaml" />
 	<arg name="right_camera_file" value="right_camera_params.yaml" />

--- a/vizzy_demos/launch/android_gui_reception_person_tracking.launch
+++ b/vizzy_demos/launch/android_gui_reception_person_tracking.launch
@@ -8,7 +8,7 @@
   <!-- robot configuration parameters -->
   <arg name="vizzy_machine_name" default="vizzy-desktop"/>
   <arg name="vizzy_machine_address" default="10.10.1.80"/>
-  <arg name="env-loader" default="/home/vizzy/catkin_workspace/devel/env.sh"/>
+  <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
   <machine name="$(arg vizzy_machine_name)" address="$(arg vizzy_machine_address)" env-loader="$(arg env-loader)" user="vizzy"/>
 
   <!-- simulation parameters and robot configuration parameters -->
@@ -49,6 +49,7 @@
   	<arg name="vizzy_machine_name" value="$(arg vizzy_machine_name)"/>
   	<arg name="vizzy_machine_address" value="$(arg vizzy_machine_address)"/>
   	<arg name="env-loader" value="$(arg env-loader)"/>
+    <arg name="define_machine" value="false"/>
   	<arg name="ros_cameras_on" value="$(arg ros_cameras_on)"/>
   	<arg name="map_file" value="$(arg map_file)" />
 	<arg name="frame_rate" value="15.0" />

--- a/vizzy_demos/launch/ball_tracking_real.launch
+++ b/vizzy_demos/launch/ball_tracking_real.launch
@@ -4,7 +4,7 @@
   <!-- robot configuration parameters -->
   <arg name="vizzy_machine_name" default="vizzy-desktop"/>
   <arg name="vizzy_machine_address" default="10.10.1.80"/>
-  <arg name="env-loader" default="/home/vizzy/catkin_workspace/devel/env.sh"/>
+  <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
   <machine name="$(arg vizzy_machine_name)" address="$(arg vizzy_machine_address)" env-loader="$(arg env-loader)" user="vizzy"/>
 
   <!-- simulation parameters and robot configuration parameters -->
@@ -41,6 +41,7 @@
   	<arg name="vizzy_machine_name" value="$(arg vizzy_machine_name)"/>
   	<arg name="vizzy_machine_address" value="$(arg vizzy_machine_address)"/>
   	<arg name="env-loader" value="$(arg env-loader)"/>
+    <arg name="define_machine" value="false"/>
   	<arg name="ros_cameras_on" value="$(arg ros_cameras_on)"/>
   </include>
   <!-- launch ball tracker -->

--- a/vizzy_demos/launch/exercise_promoter.launch
+++ b/vizzy_demos/launch/exercise_promoter.launch
@@ -5,7 +5,7 @@
   <!-- robot configuration parameters -->
   <arg name="vizzy_machine_name" default="vizzy-desktop"/>
   <arg name="vizzy_machine_address" default="10.10.1.80"/>
-  <arg name="env-loader" default="/home/vizzy/catkin_workspace/devel/env.sh"/>
+  <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
   <machine name="$(arg vizzy_machine_name)" address="$(arg vizzy_machine_address)" env-loader="$(arg env-loader)" user="vizzy"/>
 
   <!-- simulation parameters and robot configuration parameters -->
@@ -42,6 +42,7 @@
   	<arg name="vizzy_machine_name" value="$(arg vizzy_machine_name)"/>
   	<arg name="vizzy_machine_address" value="$(arg vizzy_machine_address)"/>
   	<arg name="env-loader" value="$(arg env-loader)"/>
+    <arg name="define_machine" value="false"/>
   	<arg name="ros_cameras_on" value="$(arg ros_cameras_on)"/>
   	<arg name="map_file" value="$(arg map_file)" />
 	<arg name="frame_rate" value="15.0" />

--- a/vizzy_demos/launch/follower_and_gestures_real.launch
+++ b/vizzy_demos/launch/follower_and_gestures_real.launch
@@ -4,7 +4,7 @@
   <!-- robot configuration parameters -->
   <arg name="vizzy_machine_name" default="vizzy-desktop"/>
   <arg name="vizzy_machine_address" default="10.10.1.80"/>
-  <arg name="env-loader" default="/home/vizzy/catkin_workspace/devel/env.sh"/>
+  <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
   <machine name="$(arg vizzy_machine_name)" address="$(arg vizzy_machine_address)" env-loader="$(arg env-loader)" user="vizzy"/>
 
   <!-- simulation parameters and robot configuration parameters -->
@@ -38,6 +38,7 @@
   	<arg name="vizzy_machine_name" value="$(arg vizzy_machine_name)"/>
   	<arg name="vizzy_machine_address" value="$(arg vizzy_machine_address)"/>
   	<arg name="env-loader" value="$(arg env-loader)"/>
+    <arg name="define_machine" default="false"/>
   	<arg name="ros_cameras_on" value="$(arg ros_cameras_on)"/>
   	<arg name="map_file" value="$(arg map_file)" />
   </include>

--- a/vizzy_demos/launch/gesture_recognition.launch
+++ b/vizzy_demos/launch/gesture_recognition.launch
@@ -8,7 +8,7 @@
   <!-- robot configuration parameters -->
   <arg name="vizzy_machine_name" default="vizzy-desktop"/>
   <arg name="vizzy_machine_address" default="10.10.1.80"/>
-  <arg name="env-loader" default="/home/vizzy/catkin_workspace/devel/env.sh"/>
+  <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
   <machine name="$(arg vizzy_machine_name)" address="$(arg vizzy_machine_address)" env-loader="$(arg env-loader)" user="vizzy"/>
 
   <!-- simulation parameters and robot configuration parameters -->
@@ -46,6 +46,7 @@
   	<arg name="vizzy_machine_name" value="$(arg vizzy_machine_name)"/>
   	<arg name="vizzy_machine_address" value="$(arg vizzy_machine_address)"/>
   	<arg name="env-loader" value="$(arg env-loader)"/>
+    <arg name="define_machine" value="false"/>
   	<arg name="ros_cameras_on" value="$(arg ros_cameras_on)"/>
   	<arg name="map_file" value="$(arg map_file)" />
 	<arg name="frame_rate" value="15.0" />

--- a/vizzy_demos/launch/human_gesture_vizzy_feedback.launch
+++ b/vizzy_demos/launch/human_gesture_vizzy_feedback.launch
@@ -8,7 +8,7 @@
   <!-- robot configuration parameters -->
   <arg name="vizzy_machine_name" default="vizzy-desktop"/>
   <arg name="vizzy_machine_address" default="10.10.1.80"/>
-  <arg name="env-loader" default="/home/vizzy/catkin_workspace/devel/env.sh"/>
+  <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
   <machine name="$(arg vizzy_machine_name)" address="$(arg vizzy_machine_address)" env-loader="$(arg env-loader)" user="vizzy"/>
 
   <!-- simulation parameters and robot configuration parameters -->
@@ -44,6 +44,7 @@
   	<arg name="vizzy_machine_name" value="$(arg vizzy_machine_name)"/>
   	<arg name="vizzy_machine_address" value="$(arg vizzy_machine_address)"/>
   	<arg name="env-loader" value="$(arg env-loader)"/>
+    <arg name="define_machine" value="false"/>
   	<arg name="ros_cameras_on" value="$(arg ros_cameras_on)"/>
   	<arg name="map_file" value="$(arg map_file)" />
 	<arg name="frame_rate" value="15.0" />

--- a/vizzy_demos/launch/map_creator.launch
+++ b/vizzy_demos/launch/map_creator.launch
@@ -10,7 +10,7 @@
   <!-- robot configuration parameters -->
   <arg name="vizzy_machine_name" default="vizzy-desktop"/>
   <arg name="vizzy_machine_address" default="10.10.1.80"/>
-  <arg name="env-loader" default="/home/vizzy/catkin_workspace/devel/env.sh"/>
+  <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
   <machine name="$(arg vizzy_machine_name)" address="$(arg vizzy_machine_address)" env-loader="$(arg env-loader)" user="vizzy"/>
 
   <!-- simulation parameters and robot configuration parameters -->
@@ -42,6 +42,7 @@
         <arg name="vizzy_machine_name" value="$(arg vizzy_machine_name)"/>
         <arg name="vizzy_machine_address" value="$(arg vizzy_machine_address)"/>
         <arg name="env-loader" value="$(arg env-loader)"/>
+        <arg name="define_machine" value="false"/>
         <arg name="ros_cameras_on" value="$(arg ros_cameras_on)"/>
         <arg name="map_file" value="$(arg map_file)" />
         <arg name="frame_rate" value="15.0" />

--- a/vizzy_demos/launch/navigation_seventh_floor.launch
+++ b/vizzy_demos/launch/navigation_seventh_floor.launch
@@ -4,7 +4,7 @@
   <!-- robot configuration parameters -->
   <arg name="vizzy_machine_name" default="vizzy-desktop"/>
   <arg name="vizzy_machine_address" default="10.1.3.1"/>
-  <arg name="env-loader" default="/home/vizzy/catkin_workspace/devel/env.sh"/>
+  <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
   <machine name="$(arg vizzy_machine_name)" address="$(arg vizzy_machine_address)" env-loader="$(arg env-loader)" user="vizzy"/>
   <arg name="map_file" default="rececao+atrio_TorreNorte.yaml" />
   <arg name="follower" default="true" />
@@ -38,6 +38,7 @@
   	<arg name="vizzy_machine_name" value="$(arg vizzy_machine_name)"/>
   	<arg name="vizzy_machine_address" value="$(arg vizzy_machine_address)"/>
   	<arg name="env-loader" value="$(arg env-loader)"/>
+    <arg name="define_machine" value="false"/>
   	<arg name="ros_cameras_on" value="$(arg ros_cameras_on)"/>
   	<arg name="map_file" value="$(arg map_file)" />
   </include>

--- a/vizzy_demos/launch/pedestrian_following_real.launch
+++ b/vizzy_demos/launch/pedestrian_following_real.launch
@@ -10,7 +10,7 @@
   <!-- robot configuration parameters -->
   <arg name="vizzy_machine_name" default="vizzy-desktop"/>
   <arg name="vizzy_machine_address" default="10.10.1.80"/>
-  <arg name="env-loader" default="/home/vizzy/catkin_workspace/devel/env.sh"/>
+  <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
   <machine name="$(arg vizzy_machine_name)" address="$(arg vizzy_machine_address)" env-loader="$(arg env-loader)" user="vizzy"/>
 
   <!-- simulation parameters and robot configuration parameters -->
@@ -54,6 +54,7 @@
   	<arg name="vizzy_machine_address" value="$(arg vizzy_machine_address)"/>
   	<arg name="env-loader" value="$(arg env-loader)"/>
   	<arg name="ros_cameras_on" value="$(arg ros_cameras_on)"/>
+    <arg name="define_machine" value="false"/>
   	<arg name="map_file" value="$(arg map_file)" />
 	<!-- <arg name="frame_rate" value="15.0" />
 	<arg name="left_camera_file" value="left_camera_params.yaml" />

--- a/vizzy_demos/launch/pedestrian_following_real_320x240.launch
+++ b/vizzy_demos/launch/pedestrian_following_real_320x240.launch
@@ -4,7 +4,7 @@
   <!-- robot configuration parameters -->
   <arg name="vizzy_machine_name" default="vizzy-desktop"/>
   <arg name="vizzy_machine_address" default="10.10.1.80"/>
-  <arg name="env-loader" default="/home/vizzy/catkin_workspace/devel/env.sh"/>
+  <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
   <machine name="$(arg vizzy_machine_name)" address="$(arg vizzy_machine_address)" env-loader="$(arg env-loader)" user="vizzy"/>
 
   <!-- simulation parameters and robot configuration parameters -->
@@ -43,6 +43,7 @@
   	<arg name="vizzy_machine_address" value="$(arg vizzy_machine_address)"/>
   	<arg name="env-loader" value="$(arg env-loader)"/>
   	<arg name="ros_cameras_on" value="$(arg ros_cameras_on)"/>
+    <arg name="define_machine" value="false"/>
   	<arg name="map_file" value="$(arg map_file)" />
 	<arg name="left_camera_file" default="left_camera_params_320.yaml" />
 	<arg name="right_camera_file" default="right_camera_params_320.yaml" />

--- a/vizzy_demos/launch/pedestrian_following_real_dark_env.launch
+++ b/vizzy_demos/launch/pedestrian_following_real_dark_env.launch
@@ -8,7 +8,7 @@
   <!-- robot configuration parameters -->
   <arg name="vizzy_machine_name" default="vizzy-desktop"/>
   <arg name="vizzy_machine_address" default="10.10.1.80"/>
-  <arg name="env-loader" default="/home/vizzy/catkin_workspace/devel/env.sh"/>
+  <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
   <machine name="$(arg vizzy_machine_name)" address="$(arg vizzy_machine_address)" env-loader="$(arg env-loader)" user="vizzy"/>
 
   <!-- simulation parameters and robot configuration parameters -->
@@ -50,6 +50,7 @@
   	<arg name="env-loader" value="$(arg env-loader)"/>
   	<arg name="ros_cameras_on" value="$(arg ros_cameras_on)"/>
   	<arg name="map_file" value="$(arg map_file)" />
+    <arg name="define_machine" value="false"/>
 	<arg name="frame_rate" value="15.0" />
 	<arg name="left_camera_file" value="left_camera_params.yaml" />
 	<arg name="right_camera_file" value="right_camera_params.yaml" />

--- a/vizzy_demos/launch/pedestrian_gazing_real.launch
+++ b/vizzy_demos/launch/pedestrian_gazing_real.launch
@@ -4,7 +4,7 @@
   <!-- robot configuration parameters -->
   <arg name="vizzy_machine_name" default="vizzy-desktop"/>
   <arg name="vizzy_machine_address" default="10.10.1.80"/>
-  <arg name="env-loader" default="/home/vizzy/catkin_workspace/devel/env.sh"/>
+  <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
   <machine name="$(arg vizzy_machine_name)" address="$(arg vizzy_machine_address)" env-loader="$(arg env-loader)" user="vizzy"/>
 
   <!-- simulation parameters and robot configuration parameters -->
@@ -42,6 +42,7 @@
   	<arg name="vizzy_machine_name" value="$(arg vizzy_machine_name)"/>
   	<arg name="vizzy_machine_address" value="$(arg vizzy_machine_address)"/>
   	<arg name="env-loader" value="$(arg env-loader)"/>
+    <arg name="define_machine" default="false"/>
   	<arg name="ros_cameras_on" value="$(arg ros_cameras_on)"/>
   	<arg name="map_file" value="$(arg map_file)" />
   </include>

--- a/vizzy_launch/env-hooks/env_loader.sh
+++ b/vizzy_launch/env-hooks/env_loader.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+export PYTHONPATH=$HOME/repositories/OpenFace/build/python${PYTHONPATH:+:${PYTHONPATH}}$
+export OPENCV_LIB=$HOME/repositories/opencv/build/lib
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$OPENCV_LIB
+source /opt/ros/kinetic/setup.bash
+source /home/vizzy/catkin_ws/devel/setup.bash
+export ROS_MASTER_URI=http://10.10.1.80:11311
+export ROS_IP=10.10.1.80
+export YARP_ROOT=/home/vizzy/yarp_repositories/yarp
+export YARP_DIR=$YARP_ROOT/build
+export YARP_ROBOT_NAME=vizzy
+export ICUB_ROOT=/home/vizzy/yarp_repositories/icub-main
+export ICUB_DIR=$ICUB_ROOT/build
+export VIZZY_YARP_ICUB_ROOT=/home/vizzy/catkin_ws/src/vizzy/vizzy_yarp_icub/
+export VIZZY_YARP_ICUB_DIR=$VIZZY_YARP_ICUB_ROOT/build
+export icub_firmware_shared_DIR=/home/vizzy/yarp_repositories/icub-firmware-shared/build
+export ICUBcontrib_DIR=/home/vizzy/yarp_repositories/icub-contrib-common/build
+export YARP_DATA_DIRS=$YARP_DIR/share/yarp:$ICUB_DIR/share/iCub:$ICUBcontrib_DIR/share/ICUBcontrib:$VIZZY_YARP_ICUB_DIR/share/yarp
+export YARP_COLORED_OUTPUT=1
+export YARP_FORWARD_LOG_ENABLE=1
+export PATH=$PATH:$YARP_DIR/bin:$ICUB_DIR/bin:$ICUBcontrib_DIR/bin:$VIZZY_YARP_ICUB_DIR/bin
+export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:/home/vizzy/yarp_repositories/install/lib
+
+exec "$@"

--- a/vizzy_launch/launch/vizzy_real.launch
+++ b/vizzy_launch/launch/vizzy_real.launch
@@ -4,11 +4,13 @@
   <arg name="vizzy_machine_name" default="vizzy-desktop"/>
   <arg name="vizzy_machine_address" default="10.10.1.80"/>
   <arg name="operator" default="false"/>
-  <arg name="env-loader" default="/home/vizzy/catkin_workspace/devel/env.sh"/>
+  <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
+  <arg name="define_machine" default="true"/>
   
   <machine name="$(arg vizzy_machine_name)" 
            address="$(arg vizzy_machine_address)" 
            env-loader="$(arg env-loader)" user="vizzy"
+           if="$(arg define_machine)"
   />
 
 
@@ -57,6 +59,7 @@
     <arg name="cameras_auto_gain" value="$(arg cameras_auto_gain)" />
     <arg name="cameras_auto_exposure" value="$(arg cameras_auto_exposure)" />
     <arg name="cameras_auto_frame_rate" value="$(arg cameras_auto_frame_rate)" />
+    <arg name="define_machine" value="false"/>
   </include>
 
   <!-- launch moveit -->

--- a/vizzy_launch/launch/vizzy_real.launch
+++ b/vizzy_launch/launch/vizzy_real.launch
@@ -6,12 +6,12 @@
   <arg name="operator" default="false"/>
   <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
   <arg name="define_machine" default="true"/>
-  
-  <machine name="$(arg vizzy_machine_name)" 
-           address="$(arg vizzy_machine_address)" 
-           env-loader="$(arg env-loader)" user="vizzy"
-           if="$(arg define_machine)"
-  />
+
+    <machine name="$(arg vizzy_machine_name)" 
+            address="$(arg vizzy_machine_address)" 
+            env-loader="$(arg env-loader)" user="vizzy"
+            if="$(arg define_machine)"
+    />
 
 
   <!-- robot configuration parameters -->
@@ -60,7 +60,7 @@
     <arg name="cameras_auto_exposure" value="$(arg cameras_auto_exposure)" />
     <arg name="cameras_auto_frame_rate" value="$(arg cameras_auto_frame_rate)" />
     <arg name="define_machine" value="false"/>
-  </include>
+  </include> 
 
   <!-- launch moveit -->
   <group if="$(arg use_moveit)">

--- a/vizzy_robot/launch/camera.launch
+++ b/vizzy_robot/launch/camera.launch
@@ -2,9 +2,13 @@
 <launch>
   <arg name="vizzy_machine_name" default="vizzy-desktop"/>
   <arg name="vizzy_machine_address" default="10.10.1.80"/>
-<!--  <arg name="vizzy_machine_name" default="$(arg vizzy_machine_name)" /> -->
-  <arg name="env-loader" default="/home/vizzy/catkin_workspace/devel/env.sh"/>
-  <machine name="$(arg vizzy_machine_name)" address="$(arg vizzy_machine_address)" env-loader="$(arg env-loader)" user="vizzy"/>
+  <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
+  
+  <machine name="$(arg vizzy_machine_name)" 
+           address="$(arg vizzy_machine_address)" 
+           env-loader="$(arg env-loader)" 
+           user="vizzy"
+  />
 
   <arg name="camera" default="left_camera" />
   <arg name="video_mode" default="640x480_rgb8" />

--- a/vizzy_robot/launch/camera.launch
+++ b/vizzy_robot/launch/camera.launch
@@ -3,11 +3,13 @@
   <arg name="vizzy_machine_name" default="vizzy-desktop"/>
   <arg name="vizzy_machine_address" default="10.10.1.80"/>
   <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
+  <arg name="define_machine" default="true"/> 
   
   <machine name="$(arg vizzy_machine_name)" 
            address="$(arg vizzy_machine_address)" 
            env-loader="$(arg env-loader)" 
            user="vizzy"
+           if="$(arg define_machine)"
   />
 
   <arg name="camera" default="left_camera" />

--- a/vizzy_robot/launch/real_robot.launch
+++ b/vizzy_robot/launch/real_robot.launch
@@ -6,10 +6,9 @@
   <arg name="define_machine" default="true"/>
 
   <machine name="$(arg vizzy_machine_name)" 
-           address="$(arg vizzy_machine_address)" 
-           env-loader="$(arg env-loader)" 
-           user="vizzy"
-           if="$(arg define_machine)"
+          address="$(arg vizzy_machine_address)" 
+          env-loader="$(arg env-loader)" user="vizzy"
+          if="$(arg define_machine)"
   />
 
   <arg name="map_frame" default="map" />
@@ -67,6 +66,7 @@
           <arg name="camera_id" value="2" />
           <arg name="frame_id" value="l_camera_vision_link" />
           <arg name="vizzy_machine_name" value="$(arg vizzy_machine_name)" />
+          <arg name="define_machine" default="false"/>
           <arg name="ns" value="$(arg ns)" />
           <arg name="frame_rate" value="10"/>
           <arg name="camera_intrinsics_file" value="$(find vizzy_robot)/config/left_camera_params.yaml" />
@@ -81,6 +81,7 @@
         <arg name="camera_id" value="1"/>
         <arg name="frame_id" value="r_camera_vision_link" />
         <arg name="vizzy_machine_name" value="$(arg vizzy_machine_name)" />
+        <arg name="define_machine" default="false"/>
         <arg name="ns" value="$(arg ns)" />
         <arg name="frame_rate" value="10"/>
         <arg name="camera_intrinsics_file" value="$(find vizzy_robot)/config/right_camera_params.yaml" />

--- a/vizzy_robot/launch/real_robot.launch
+++ b/vizzy_robot/launch/real_robot.launch
@@ -2,11 +2,14 @@
 <launch>
   <arg name="vizzy_machine_name" default="vizzy-desktop"/>
   <arg name="vizzy_machine_address" default="10.10.1.80"/>
-  <arg name="env-loader" default="/home/vizzy/catkin_workspace/devel/env.sh"/>
+  <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
+  <arg name="define_machine" default="true"/>
+
   <machine name="$(arg vizzy_machine_name)" 
            address="$(arg vizzy_machine_address)" 
            env-loader="$(arg env-loader)" 
            user="vizzy"
+           if="$(arg define_machine)"
   />
 
   <arg name="map_frame" default="map" />

--- a/vizzy_robot/launch/ueye_camera.launch
+++ b/vizzy_robot/launch/ueye_camera.launch
@@ -5,12 +5,13 @@
   <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
   <arg name="define_machine" default="true"/>
 
-  <machine name="$(arg vizzy_machine_name)" 
-           address="$(arg vizzy_machine_address)" 
-           env-loader="$(arg env-loader)" 
-           user="vizzy"
-           if="$(arg define_machine)"
-  />
+  <group if="$(arg define_machine)">
+    <machine name="$(arg vizzy_machine_name)" 
+            address="$(arg vizzy_machine_address)" 
+            env-loader="$(arg env-loader)" user="vizzy"
+            if="$(arg define_machine)"
+    />
+  </group>
 
   <arg name="ns" default="vizzy" />
   <arg name="camera_name" default="camera" />

--- a/vizzy_robot/launch/ueye_camera.launch
+++ b/vizzy_robot/launch/ueye_camera.launch
@@ -2,12 +2,14 @@
 <launch>
   <arg name="vizzy_machine_name" default="vizzy-desktop"/>
   <arg name="vizzy_machine_address" default="10.10.1.80"/>
-  <arg name="env-loader" default="/home/vizzy/catkin_workspace/devel/env.sh"/>
-  
+  <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
+  <arg name="define_machine" default="true"/>
+
   <machine name="$(arg vizzy_machine_name)" 
            address="$(arg vizzy_machine_address)" 
            env-loader="$(arg env-loader)" 
            user="vizzy"
+           if="$(arg define_machine)"
   />
 
   <arg name="ns" default="vizzy" />

--- a/vizzy_robot/launch/ueye_camera.launch
+++ b/vizzy_robot/launch/ueye_camera.launch
@@ -5,13 +5,11 @@
   <arg name="env-loader" default="$(find vizzy_launch)/env-hooks/env_loader.sh"/>
   <arg name="define_machine" default="true"/>
 
-  <group if="$(arg define_machine)">
-    <machine name="$(arg vizzy_machine_name)" 
-            address="$(arg vizzy_machine_address)" 
-            env-loader="$(arg env-loader)" user="vizzy"
-            if="$(arg define_machine)"
-    />
-  </group>
+  <machine name="$(arg vizzy_machine_name)" 
+        address="$(arg vizzy_machine_address)" 
+        env-loader="$(arg env-loader)" user="vizzy"
+        if="$(arg define_machine)"
+  />
 
   <arg name="ns" default="vizzy" />
   <arg name="camera_name" default="camera" />


### PR DESCRIPTION
Now we successfully avoid duplicate "machine" definitions on subsequent launch files. There was a missing flag on camera.launch on https://github.com/vislab-tecnico-lisboa/vizzy/pull/110 and that's why I closed it and opened a new pull request.