### PR TITLE
Realsense is now working on Gazebo. Tested on ROS Melodic.

### DIFF
--- a/vizzy_description/urdf/sensors/_d435.gazebo.xacro
+++ b/vizzy_description/urdf/sensors/_d435.gazebo.xacro
@@ -1,0 +1,146 @@
+<?xml version="1.0"?>
+
+<!--
+License: Apache 2.0. See LICENSE file in root directory.
+Copyright(c) 2017 PAL Robotics, S.L. All Rights Reserved
+
+This is the Gazebo URDF model for the Intel RealSense D435 camera
+-->
+  
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  
+  <xacro:macro name="gazebo_d435" params="camera_name reference_link topics_ns depth_optical_frame color_optical_frame infrared1_optical_frame infrared2_optical_frame" >
+
+    <!-- Load parameters to model's main link-->
+    <xacro:property name="deg_to_rad" value="0.01745329251994329577" />
+    <gazebo reference="${reference_link}">
+      <self_collide>0</self_collide>
+      <enable_wind>0</enable_wind>
+      <kinematic>0</kinematic>
+      <gravity>1</gravity>
+      <!--<mu>1</mu>-->
+      <mu2>1</mu2>
+      <fdir1>0 0 0</fdir1>
+      <!--<slip1>0</slip1>
+      <slip2>0</slip2>-->
+      <kp>1e+13</kp>
+      <kd>1</kd>
+      <!--<max_vel>0.01</max_vel>
+      <min_depth>0</min_depth>-->
+      <sensor name="${camera_name}color" type="camera">
+        <camera name="${camera_name}">
+          <horizontal_fov>${69.4*deg_to_rad}</horizontal_fov>
+          <image>
+            <width>1920</width>
+            <height>1080</height>
+            <format>RGB_INT8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.007</stddev>
+          </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <visualize>1</visualize>
+      </sensor>
+      <sensor name="${camera_name}ired1" type="camera">
+        <camera name="${camera_name}">
+          <horizontal_fov>${85.2*deg_to_rad}</horizontal_fov>
+          <image>
+            <width>1280</width>
+            <height>720</height>
+            <format>L_INT8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.05</stddev>
+          </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>90</update_rate>
+        <visualize>0</visualize>
+      </sensor>
+      <sensor name="${camera_name}ired2" type="camera">
+        <camera name="${camera_name}">
+          <horizontal_fov>${85.2*deg_to_rad}</horizontal_fov>
+          <image>
+            <width>1280</width>
+            <height>720</height>
+            <format>L_INT8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.05</stddev>
+          </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>90</update_rate>
+        <visualize>0</visualize>
+      </sensor>
+      <sensor name="${camera_name}depth" type="depth">
+        <camera name="${camera_name}">
+          <horizontal_fov>${85.2*deg_to_rad}</horizontal_fov>
+          <image>
+            <width>1280</width>
+            <height>720</height>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.100</stddev>
+          </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>90</update_rate>
+        <visualize>0</visualize>
+      </sensor>
+    </gazebo>
+
+    <gazebo>
+      <plugin name="${topics_ns}" filename="librealsense_gazebo_plugin.so">
+        <prefix>${camera_name}</prefix>
+      	<depthUpdateRate>60.0</depthUpdateRate>
+      	<colorUpdateRate>60.0</colorUpdateRate>
+      	<infraredUpdateRate>60.0</infraredUpdateRate>
+      	<depthTopicName>depth/image_raw</depthTopicName>
+      	<depthCameraInfoTopicName>depth/camera_info</depthCameraInfoTopicName>
+      	<colorTopicName>color/image_raw</colorTopicName>
+      	<colorCameraInfoTopicName>color/camera_info</colorCameraInfoTopicName>
+      	<infrared1TopicName>infra1/image_raw</infrared1TopicName>
+      	<infrared1CameraInfoTopicName>infra1/camera_info</infrared1CameraInfoTopicName>
+      	<infrared2TopicName>infra2/image_raw</infrared2TopicName>
+      	<infrared2CameraInfoTopicName>infra2/camera_info</infrared2CameraInfoTopicName>
+      	<colorOpticalframeName>${color_optical_frame}</colorOpticalframeName>
+      	<depthOpticalframeName>${depth_optical_frame}</depthOpticalframeName>
+      	<infrared1OpticalframeName>${infrared1_optical_frame}</infrared1OpticalframeName>
+      	<infrared2OpticalframeName>${infrared2_optical_frame}</infrared2OpticalframeName>
+      	<rangeMinDepth>0.2</rangeMinDepth>
+      	<rangeMaxDepth>10.0</rangeMaxDepth>
+      	<pointCloud>true</pointCloud>
+      	<pointCloudTopicName>depth/points</pointCloudTopicName>
+      	<pointCloudCutoff>0.5</pointCloudCutoff>
+      </plugin>
+    </gazebo>
+
+  </xacro:macro>
+</robot>

--- a/vizzy_description/urdf/sensors/_d435.gazebo.xacro
+++ b/vizzy_description/urdf/sensors/_d435.gazebo.xacro
@@ -117,7 +117,7 @@ This is the Gazebo URDF model for the Intel RealSense D435 camera
     </gazebo>
 
     <gazebo>
-      <plugin name="${topics_ns}" filename="librealsense_gazebo_plugin.so">
+      <plugin name="${topics_ns}" filename="libvizzyrealsense_gazebo_plugin.so">
         <prefix>${camera_name}</prefix>
       	<depthUpdateRate>60.0</depthUpdateRate>
       	<colorUpdateRate>60.0</colorUpdateRate>

--- a/vizzy_description/urdf/sensors/_d435.urdf.xacro
+++ b/vizzy_description/urdf/sensors/_d435.urdf.xacro
@@ -8,8 +8,13 @@ This is the URDF model for the Intel RealSense 430 camera, in it's
 aluminum peripherial evaluation case.
 -->
 
+
 <robot name="sensor_d435" xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="sensor_d435" params="name parent *origin">
+
+  <!--File includes-->
+  <xacro:include filename="$(find vizzy_description)/urdf/sensors/_d435.gazebo.xacro"/>
+
+  <xacro:macro name="sensor_d435" params="name parent topics_ns:=realsense *origin">
     <xacro:property name="M_PI" value="3.1415926535897931" />
   
     <!-- The following values are approximate, and the camera node
@@ -135,5 +140,9 @@ aluminum peripherial evaluation case.
       <child link="${name}_color_optical_frame" />
     </joint>
     <link name="${name}_color_optical_frame"/>
+
+    <!-- Realsense Gazebo Plugin -->
+    <xacro:gazebo_d435 camera_name="${name}" reference_link="${name}_link" topics_ns="${topics_ns}" depth_optical_frame="${name}_depth_optical_frame" color_optical_frame="${name}_color_optical_frame" infrared1_optical_frame="${name}_left_ir_optical_frame" infrared2_optical_frame="${name}_right_ir_optical_frame"/>
+
   </xacro:macro>
 </robot>

--- a/vizzy_sensors/CMakeLists.txt
+++ b/vizzy_sensors/CMakeLists.txt
@@ -12,7 +12,14 @@ find_package(catkin REQUIRED
     roscpp
     roslint
     sensor_msgs
-    tf)
+    gazebo_ros
+    gazebo_msgs
+    image_transport
+    camera_info_manager
+    )
+
+
+find_package(gazebo REQUIRED)
 
 catkin_package(
   CATKIN_DEPENDS
@@ -23,13 +30,32 @@ catkin_package(
     pcl_ros
     sensor_msgs
     tf
+    gazebo_ros
+    image_transport
+    camera_info_manager
   INCLUDE_DIRS
     include
   LIBRARIES
     vizzy_sensors_filters
 )
 
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(include 
+                    ${catkin_INCLUDE_DIRS}
+                    SYSTEM
+                    ${GAZEBO_INCLUDE_DIRS})
+
+link_directories(${GAZEBO_LIBRARY_DIRS})
+
+
+## Declare a library
+add_library(
+    realsense_gazebo_plugin
+    src/RealSensePlugin.cpp
+    src/gazebo_ros_realsense.cpp
+    )
+
+target_link_libraries(realsense_gazebo_plugin ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
+add_dependencies(realsense_gazebo_plugin ${catkin_EXPORTED_TARGETS})
 
 
 ## Declare a cpp executable

--- a/vizzy_sensors/CMakeLists.txt
+++ b/vizzy_sensors/CMakeLists.txt
@@ -49,13 +49,13 @@ link_directories(${GAZEBO_LIBRARY_DIRS})
 
 ## Declare a library
 add_library(
-    realsense_gazebo_plugin
+    vizzyrealsense_gazebo_plugin
     src/RealSensePlugin.cpp
     src/gazebo_ros_realsense.cpp
     )
 
-target_link_libraries(realsense_gazebo_plugin ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
-add_dependencies(realsense_gazebo_plugin ${catkin_EXPORTED_TARGETS})
+target_link_libraries(vizzyrealsense_gazebo_plugin ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
+add_dependencies(vizzyrealsense_gazebo_plugin ${catkin_EXPORTED_TARGETS})
 
 
 ## Declare a cpp executable

--- a/vizzy_sensors/README
+++ b/vizzy_sensors/README
@@ -1,0 +1,5 @@
+This package contains code to make Vizzy's sensors work.
+
+The Gazebo plugin that simulates the Realsense depth camera was previously published on: https://github.com/pal-robotics/realsense_gazebo_plugin and from https://github.com/pal-robotics-forks/realsense/tree/upstream/realsense2_description/urdf.
+We added their code to this package to avoid additional dependencies.
+

--- a/vizzy_sensors/include/realsense_gazebo_plugin/RealSensePlugin.h
+++ b/vizzy_sensors/include/realsense_gazebo_plugin/RealSensePlugin.h
@@ -1,0 +1,139 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#ifndef _GZRS_PLUGIN_HH_
+#define _GZRS_PLUGIN_HH_
+
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/common/common.hh>
+#include <gazebo/physics/PhysicsTypes.hh>
+#include <gazebo/physics/physics.hh>
+#include <gazebo/rendering/DepthCamera.hh>
+#include <gazebo/sensors/sensors.hh>
+#include <sdf/sdf.hh>
+
+#include <memory>
+#include <string>
+
+namespace gazebo {
+#define DEPTH_CAMERA_NAME "depth"
+#define COLOR_CAMERA_NAME "color"
+#define IRED1_CAMERA_NAME "ired1"
+#define IRED2_CAMERA_NAME "ired2"
+
+struct CameraParams {
+  CameraParams() {}
+
+  std::string topic_name;
+  std::string camera_info_topic_name;
+  std::string optical_frame;
+};
+
+/// \brief A plugin that simulates Real Sense camera streams.
+class RealSensePlugin : public ModelPlugin {
+  /// \brief Constructor.
+public:
+  RealSensePlugin();
+
+  /// \brief Destructor.
+  ~RealSensePlugin();
+
+  // Documentation Inherited.
+  virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+
+  /// \brief Callback for the World Update event.
+  void OnUpdate();
+
+  /// \brief Callback that publishes a received Depth Camera Frame as an
+  /// ImageStamped
+  /// message.
+  virtual void OnNewDepthFrame();
+
+  /// \brief Callback that publishes a received Camera Frame as an
+  /// ImageStamped message.
+  virtual void OnNewFrame(const rendering::CameraPtr cam,
+                          const transport::PublisherPtr pub);
+
+protected:
+  /// \brief Pointer to the model containing the plugin.
+  physics::ModelPtr rsModel;
+
+  /// \brief Pointer to the world.
+  physics::WorldPtr world;
+
+  /// \brief Pointer to the Depth Camera Renderer.
+  rendering::DepthCameraPtr depthCam;
+
+  /// \brief Pointer to the Color Camera Renderer.
+  rendering::CameraPtr colorCam;
+
+  /// \brief Pointer to the Infrared Camera Renderer.
+  rendering::CameraPtr ired1Cam;
+
+  /// \brief Pointer to the Infrared2 Camera Renderer.
+  rendering::CameraPtr ired2Cam;
+
+  /// \brief String to hold the camera prefix
+  std::string prefix;
+
+  /// \brief Pointer to the transport Node.
+  transport::NodePtr transportNode;
+
+  // \brief Store Real Sense depth map data.
+  std::vector<uint16_t> depthMap;
+
+  /// \brief Pointer to the Depth Publisher.
+  transport::PublisherPtr depthPub;
+
+  /// \brief Pointer to the Color Publisher.
+  transport::PublisherPtr colorPub;
+
+  /// \brief Pointer to the Infrared Publisher.
+  transport::PublisherPtr ired1Pub;
+
+  /// \brief Pointer to the Infrared2 Publisher.
+  transport::PublisherPtr ired2Pub;
+
+  /// \brief Pointer to the Depth Camera callback connection.
+  event::ConnectionPtr newDepthFrameConn;
+
+  /// \brief Pointer to the Depth Camera callback connection.
+  event::ConnectionPtr newIred1FrameConn;
+
+  /// \brief Pointer to the Infrared Camera callback connection.
+  event::ConnectionPtr newIred2FrameConn;
+
+  /// \brief Pointer to the Color Camera callback connection.
+  event::ConnectionPtr newColorFrameConn;
+
+  /// \brief Pointer to the World Update event connection.
+  event::ConnectionPtr updateConnection;
+
+  std::map<std::string, CameraParams> cameraParamsMap_;
+
+  bool pointCloud_ = false;
+  std::string pointCloudTopic_;
+  double pointCloudCutOff_, pointCloudCutOffMax_;
+
+  double colorUpdateRate_;
+  double infraredUpdateRate_;
+  double depthUpdateRate_;
+
+  float rangeMinDepth_;
+  float rangeMaxDepth_;
+};
+}
+#endif

--- a/vizzy_sensors/include/realsense_gazebo_plugin/gazebo_ros_realsense.h
+++ b/vizzy_sensors/include/realsense_gazebo_plugin/gazebo_ros_realsense.h
@@ -1,0 +1,70 @@
+#ifndef _GAZEBO_ROS_REALSENSE_PLUGIN_
+#define _GAZEBO_ROS_REALSENSE_PLUGIN_
+
+#include "realsense_gazebo_plugin/RealSensePlugin.h"
+
+#include <ros/ros.h>
+#include <sensor_msgs/CameraInfo.h>
+#include <sensor_msgs/Image.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <sensor_msgs/image_encodings.h>
+
+#include <camera_info_manager/camera_info_manager.h>
+#include <image_transport/image_transport.h>
+
+#include <memory>
+#include <string>
+
+namespace gazebo {
+/// \brief A plugin that simulates Real Sense camera streams.
+class GazeboRosRealsense : public RealSensePlugin {
+  /// \brief Constructor.
+public:
+  GazeboRosRealsense();
+
+  /// \brief Destructor.
+public:
+  ~GazeboRosRealsense();
+
+  // Documentation Inherited.
+public:
+  virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+
+  /// \brief Callback that publishes a received Depth Camera Frame as an
+  /// ImageStamped message.
+public:
+  virtual void OnNewDepthFrame();
+
+  /// \brief Helper function to fill the pointcloud information
+  bool FillPointCloudHelper(sensor_msgs::PointCloud2 &point_cloud_msg, uint32_t rows_arg,
+                            uint32_t cols_arg, uint32_t step_arg, void *data_arg);
+
+  /// \brief Callback that publishes a received Camera Frame as an
+  /// ImageStamped message.
+public:
+  virtual void OnNewFrame(const rendering::CameraPtr cam,
+                          const transport::PublisherPtr pub);
+
+protected:
+  boost::shared_ptr<camera_info_manager::CameraInfoManager>
+      camera_info_manager_;
+
+  /// \brief A pointer to the ROS node.
+  ///  A node will be instantiated if it does not exist.
+protected:
+  ros::NodeHandle *rosnode_;
+
+private:
+  image_transport::ImageTransport *itnode_;
+  ros::Publisher pointcloud_pub_;
+
+protected:
+  image_transport::CameraPublisher color_pub_, ir1_pub_, ir2_pub_, depth_pub_;
+
+  /// \brief ROS image messages
+protected:
+  sensor_msgs::Image image_msg_, depth_msg_;
+  sensor_msgs::PointCloud2 pointcloud_msg_;
+};
+}
+#endif /* _GAZEBO_ROS_REALSENSE_PLUGIN_ */

--- a/vizzy_sensors/package.xml
+++ b/vizzy_sensors/package.xml
@@ -29,6 +29,9 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>roslaunch</build_depend>
+  <build_depend>gazebo_ros</build_depend>
+  <build_depend>image_transport</build_depend>
+  <build_depend>camera_info_manager</build_depend>
 
   <run_depend>camera1394</run_depend>
   <run_depend>depthimage_to_laserscan</run_depend>
@@ -48,8 +51,16 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>tf2_ros</run_depend>
+  <run_depend>gazebo_ros</run_depend>
+  <run_depend>image_transport</run_depend>
+  <run_depend>camera_info_manager</run_depend>
 
   <export>
     <filters plugin="${prefix}/vizzy_sensors_plugins.xml"/>
+      <gazebo_ros
+        plugin_path="${prefix}/lib"
+        gazebo_media_path="${prefix}"
+        gazebo_model_path="${prefix}/models"
+      />
   </export>
 </package>

--- a/vizzy_sensors/src/RealSensePlugin.cpp
+++ b/vizzy_sensors/src/RealSensePlugin.cpp
@@ -1,0 +1,280 @@
+
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#include "realsense_gazebo_plugin/RealSensePlugin.h"
+#include <gazebo/physics/physics.hh>
+#include <gazebo/rendering/DepthCamera.hh>
+#include <gazebo/sensors/sensors.hh>
+
+#define DEPTH_SCALE_M 0.001
+
+#define DEPTH_CAMERA_TOPIC "depth"
+#define COLOR_CAMERA_TOPIC "color"
+#define IRED1_CAMERA_TOPIC "infrared"
+#define IRED2_CAMERA_TOPIC "infrared2"
+
+using namespace gazebo;
+
+/////////////////////////////////////////////////
+RealSensePlugin::RealSensePlugin() {
+  this->depthCam = nullptr;
+  this->ired1Cam = nullptr;
+  this->ired2Cam = nullptr;
+  this->colorCam = nullptr;
+  this->prefix = "";
+  this->pointCloudCutOffMax_ = 5.0;
+}
+
+/////////////////////////////////////////////////
+RealSensePlugin::~RealSensePlugin() {}
+
+/////////////////////////////////////////////////
+void RealSensePlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
+  // Output the name of the model
+  std::cout
+      << std::endl
+      << "RealSensePlugin: The realsense_camera plugin is attach to model "
+      << _model->GetName() << std::endl;
+
+  _sdf = _sdf->GetFirstElement();
+
+  cameraParamsMap_.insert(std::make_pair(COLOR_CAMERA_NAME, CameraParams()));
+  cameraParamsMap_.insert(std::make_pair(DEPTH_CAMERA_NAME, CameraParams()));
+  cameraParamsMap_.insert(std::make_pair(IRED1_CAMERA_NAME, CameraParams()));
+  cameraParamsMap_.insert(std::make_pair(IRED2_CAMERA_NAME, CameraParams()));
+
+  do {
+    std::string name = _sdf->GetName();
+    if (name == "depthUpdateRate")
+      _sdf->GetValue()->Get(depthUpdateRate_);
+    else if (name == "colorUpdateRate")
+      _sdf->GetValue()->Get(colorUpdateRate_);
+    else if (name == "infraredUpdateRate")
+      _sdf->GetValue()->Get(infraredUpdateRate_);
+    else if (name == "depthTopicName")
+      cameraParamsMap_[DEPTH_CAMERA_NAME].topic_name =
+          _sdf->GetValue()->GetAsString();
+    else if (name == "depthCameraInfoTopicName")
+      cameraParamsMap_[DEPTH_CAMERA_NAME].camera_info_topic_name =
+          _sdf->GetValue()->GetAsString();
+    else if (name == "colorTopicName")
+      cameraParamsMap_[COLOR_CAMERA_NAME].topic_name =
+          _sdf->GetValue()->GetAsString();
+    else if (name == "colorCameraInfoTopicName")
+      cameraParamsMap_[COLOR_CAMERA_NAME].camera_info_topic_name =
+          _sdf->GetValue()->GetAsString();
+    else if (name == "infrared1TopicName")
+      cameraParamsMap_[IRED1_CAMERA_NAME].topic_name =
+          _sdf->GetValue()->GetAsString();
+    else if (name == "infrared1CameraInfoTopicName")
+      cameraParamsMap_[IRED1_CAMERA_NAME].camera_info_topic_name =
+          _sdf->GetValue()->GetAsString();
+    else if (name == "infrared2TopicName")
+      cameraParamsMap_[IRED2_CAMERA_NAME].topic_name =
+          _sdf->GetValue()->GetAsString();
+    else if (name == "infrared2CameraInfoTopicName")
+      cameraParamsMap_[IRED2_CAMERA_NAME].camera_info_topic_name =
+          _sdf->GetValue()->GetAsString();
+    else if (name == "colorOpticalframeName")
+      cameraParamsMap_[COLOR_CAMERA_NAME].optical_frame =
+          _sdf->GetValue()->GetAsString();
+    else if (name == "depthOpticalframeName")
+      cameraParamsMap_[DEPTH_CAMERA_NAME].optical_frame =
+          _sdf->GetValue()->GetAsString();
+    else if (name == "infrared1OpticalframeName")
+      cameraParamsMap_[IRED1_CAMERA_NAME].optical_frame =
+          _sdf->GetValue()->GetAsString();
+    else if (name == "infrared2OpticalframeName")
+      cameraParamsMap_[IRED2_CAMERA_NAME].optical_frame =
+          _sdf->GetValue()->GetAsString();
+    else if (name == "rangeMinDepth")
+      _sdf->GetValue()->Get(rangeMinDepth_);
+    else if (name == "rangeMaxDepth")
+      _sdf->GetValue()->Get(rangeMaxDepth_);
+    else if (name == "pointCloud")
+      _sdf->GetValue()->Get(pointCloud_);
+    else if (name == "pointCloudTopicName")
+      pointCloudTopic_ = _sdf->GetValue()->GetAsString();
+    else if (name == "pointCloudCutoff")
+      _sdf->GetValue()->Get(pointCloudCutOff_);
+    else if (name == "pointCloudCutoffMax")
+      _sdf->GetValue()->Get(pointCloudCutOffMax_);
+    else if (name == "prefix")
+      this->prefix = _sdf->GetValue()->GetAsString();
+    else if (name == "robotNamespace")
+      break;
+    else
+      throw std::runtime_error("Ivalid parameter for ReakSensePlugin");
+
+    _sdf = _sdf->GetNextElement();
+  } while (_sdf);
+
+  // Store a pointer to the this model
+  this->rsModel = _model;
+
+  // Store a pointer to the world
+  this->world = this->rsModel->GetWorld();
+
+  // Sensors Manager
+  sensors::SensorManager *smanager = sensors::SensorManager::Instance();
+
+  // Get Cameras Renderers
+  this->depthCam = std::dynamic_pointer_cast<sensors::DepthCameraSensor>(
+                       smanager->GetSensor(prefix + DEPTH_CAMERA_NAME))
+                       ->DepthCamera();
+
+  this->ired1Cam = std::dynamic_pointer_cast<sensors::CameraSensor>(
+                       smanager->GetSensor(prefix + IRED1_CAMERA_NAME))
+                       ->Camera();
+  this->ired2Cam = std::dynamic_pointer_cast<sensors::CameraSensor>(
+                       smanager->GetSensor(prefix + IRED2_CAMERA_NAME))
+                       ->Camera();
+  this->colorCam = std::dynamic_pointer_cast<sensors::CameraSensor>(
+                       smanager->GetSensor(prefix + COLOR_CAMERA_NAME))
+                       ->Camera();
+
+  // Check if camera renderers have been found successfuly
+  if (!this->depthCam) {
+    std::cerr << "RealSensePlugin: Depth Camera has not been found"
+              << std::endl;
+    return;
+  }
+  if (!this->ired1Cam) {
+    std::cerr << "RealSensePlugin: InfraRed Camera 1 has not been found"
+              << std::endl;
+    return;
+  }
+  if (!this->ired2Cam) {
+    std::cerr << "RealSensePlugin: InfraRed Camera 2 has not been found"
+              << std::endl;
+    return;
+  }
+  if (!this->colorCam) {
+    std::cerr << "RealSensePlugin: Color Camera has not been found"
+              << std::endl;
+    return;
+  }
+
+  // Resize Depth Map dimensions
+  try {
+    this->depthMap.resize(this->depthCam->ImageWidth() *
+                          this->depthCam->ImageHeight());
+  } catch (std::bad_alloc &e) {
+    std::cerr << "RealSensePlugin: depthMap allocation failed: " << e.what()
+              << std::endl;
+    return;
+  }
+
+  // Setup Transport Node
+  this->transportNode = transport::NodePtr(new transport::Node());
+  this->transportNode->Init(this->world->Name());
+
+  // Setup Publishers
+  std::string rsTopicRoot = "~/" + this->rsModel->GetName();
+
+  this->depthPub = this->transportNode->Advertise<msgs::ImageStamped>(
+      rsTopicRoot + DEPTH_CAMERA_TOPIC, 1, depthUpdateRate_);
+  this->ired1Pub = this->transportNode->Advertise<msgs::ImageStamped>(
+      rsTopicRoot + IRED1_CAMERA_TOPIC, 1, infraredUpdateRate_);
+  this->ired2Pub = this->transportNode->Advertise<msgs::ImageStamped>(
+      rsTopicRoot + IRED2_CAMERA_TOPIC, 1, infraredUpdateRate_);
+  this->colorPub = this->transportNode->Advertise<msgs::ImageStamped>(
+      rsTopicRoot + COLOR_CAMERA_TOPIC, 1, colorUpdateRate_);
+
+  // Listen to depth camera new frame event
+  this->newDepthFrameConn = this->depthCam->ConnectNewDepthFrame(
+      std::bind(&RealSensePlugin::OnNewDepthFrame, this));
+
+  this->newIred1FrameConn = this->ired1Cam->ConnectNewImageFrame(std::bind(
+      &RealSensePlugin::OnNewFrame, this, this->ired1Cam, this->ired1Pub));
+
+  this->newIred2FrameConn = this->ired2Cam->ConnectNewImageFrame(std::bind(
+      &RealSensePlugin::OnNewFrame, this, this->ired2Cam, this->ired2Pub));
+
+  this->newColorFrameConn = this->colorCam->ConnectNewImageFrame(std::bind(
+      &RealSensePlugin::OnNewFrame, this, this->colorCam, this->colorPub));
+
+  // Listen to the update event
+  this->updateConnection = event::Events::ConnectWorldUpdateBegin(
+      boost::bind(&RealSensePlugin::OnUpdate, this));
+}
+
+/////////////////////////////////////////////////
+void RealSensePlugin::OnNewFrame(const rendering::CameraPtr cam,
+                                 const transport::PublisherPtr pub) {
+  msgs::ImageStamped msg;
+
+  // Set Simulation Time
+  msgs::Set(msg.mutable_time(), this->world->SimTime());
+
+  // Set Image Dimensions
+  msg.mutable_image()->set_width(cam->ImageWidth());
+  msg.mutable_image()->set_height(cam->ImageHeight());
+
+  // Set Image Pixel Format
+  msg.mutable_image()->set_pixel_format(
+      common::Image::ConvertPixelFormat(cam->ImageFormat()));
+
+  // Set Image Data
+  msg.mutable_image()->set_step(cam->ImageWidth() * cam->ImageDepth());
+  msg.mutable_image()->set_data(cam->ImageData(),
+                                cam->ImageDepth() * cam->ImageWidth() *
+                                    cam->ImageHeight());
+
+  // Publish realsense infrared stream
+  pub->Publish(msg);
+}
+
+/////////////////////////////////////////////////
+void RealSensePlugin::OnNewDepthFrame() {
+  // Get Depth Map dimensions
+  unsigned int imageSize =
+      this->depthCam->ImageWidth() * this->depthCam->ImageHeight();
+
+  // Instantiate message
+  msgs::ImageStamped msg;
+
+  // Convert Float depth data to RealSense depth data
+  const float *depthDataFloat = this->depthCam->DepthData();
+  for (unsigned int i = 0; i < imageSize; ++i) {
+    // Check clipping and overflow
+    if (depthDataFloat[i] < rangeMinDepth_ ||
+        depthDataFloat[i] > rangeMaxDepth_ ||
+        depthDataFloat[i] > DEPTH_SCALE_M * UINT16_MAX ||
+        depthDataFloat[i] < 0) {
+      this->depthMap[i] = 0;
+    } else {
+      this->depthMap[i] = (uint16_t)(depthDataFloat[i] / DEPTH_SCALE_M);
+    }
+  }
+
+  // Pack realsense scaled depth map
+  msgs::Set(msg.mutable_time(), this->world->SimTime());
+  msg.mutable_image()->set_width(this->depthCam->ImageWidth());
+  msg.mutable_image()->set_height(this->depthCam->ImageHeight());
+  msg.mutable_image()->set_pixel_format(common::Image::L_INT16);
+  msg.mutable_image()->set_step(this->depthCam->ImageWidth() *
+                                this->depthCam->ImageDepth());
+  msg.mutable_image()->set_data(this->depthMap.data(),
+                                sizeof(*this->depthMap.data()) * imageSize);
+
+  // Publish realsense scaled depth map
+  this->depthPub->Publish(msg);
+}
+
+/////////////////////////////////////////////////
+void RealSensePlugin::OnUpdate() {}

--- a/vizzy_sensors/src/gazebo_ros_realsense.cpp
+++ b/vizzy_sensors/src/gazebo_ros_realsense.cpp
@@ -1,0 +1,276 @@
+#include "realsense_gazebo_plugin/gazebo_ros_realsense.h"
+#include <sensor_msgs/fill_image.h>
+#include <sensor_msgs/point_cloud2_iterator.h>
+
+namespace {
+std::string extractCameraName(const std::string &name);
+sensor_msgs::CameraInfo cameraInfo(const sensor_msgs::Image &image,
+                                   float horizontal_fov);
+}
+
+namespace gazebo {
+// Register the plugin
+GZ_REGISTER_MODEL_PLUGIN(GazeboRosRealsense)
+
+GazeboRosRealsense::GazeboRosRealsense() {}
+
+GazeboRosRealsense::~GazeboRosRealsense() {
+  ROS_DEBUG_STREAM_NAMED("realsense_camera", "Unloaded");
+}
+
+void GazeboRosRealsense::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
+  // Make sure the ROS node for Gazebo has already been initialized
+  if (!ros::isInitialized()) {
+    ROS_FATAL_STREAM("A ROS node for Gazebo has not been initialized, unable "
+                     "to load plugin. "
+                     << "Load the Gazebo system plugin "
+                        "'libgazebo_ros_api_plugin.so' in the gazebo_ros "
+                        "package)");
+    return;
+  }
+  ROS_INFO("Realsense Gazebo ROS plugin loading.");
+
+  RealSensePlugin::Load(_model, _sdf);
+
+  this->rosnode_ = new ros::NodeHandle(this->GetHandle());
+
+  // initialize camera_info_manager
+  this->camera_info_manager_.reset(
+      new camera_info_manager::CameraInfoManager(*this->rosnode_, this->GetHandle()));
+
+  this->itnode_ = new image_transport::ImageTransport(*this->rosnode_);
+
+  this->color_pub_ = this->itnode_->advertiseCamera(
+      cameraParamsMap_[COLOR_CAMERA_NAME].topic_name, 2);
+  this->ir1_pub_ = this->itnode_->advertiseCamera(
+      cameraParamsMap_[IRED1_CAMERA_NAME].topic_name, 2);
+  this->ir2_pub_ = this->itnode_->advertiseCamera(
+      cameraParamsMap_[IRED2_CAMERA_NAME].topic_name, 2);
+  this->depth_pub_ = this->itnode_->advertiseCamera(
+      cameraParamsMap_[DEPTH_CAMERA_NAME].topic_name, 2);
+  if (pointCloud_)
+  {
+    this->pointcloud_pub_ =
+        this->rosnode_->advertise<sensor_msgs::PointCloud2>(pointCloudTopic_, 2, false);
+  }
+}
+
+void GazeboRosRealsense::OnNewFrame(const rendering::CameraPtr cam,
+                                    const transport::PublisherPtr pub) {
+  common::Time current_time = this->world->SimTime();
+
+  // identify camera
+  std::string camera_id = extractCameraName(cam->Name());
+  const std::map<std::string, image_transport::CameraPublisher *>
+      camera_publishers = {
+          {COLOR_CAMERA_NAME, &(this->color_pub_)},
+          {IRED1_CAMERA_NAME, &(this->ir1_pub_)},
+          {IRED2_CAMERA_NAME, &(this->ir2_pub_)},
+      };
+  const auto image_pub = camera_publishers.at(camera_id);
+
+  // copy data into image
+  this->image_msg_.header.frame_id =
+      this->cameraParamsMap_[camera_id].optical_frame;
+  this->image_msg_.header.stamp.sec = current_time.sec;
+  this->image_msg_.header.stamp.nsec = current_time.nsec;
+
+  // set image encoding
+  const std::map<std::string, std::string> supported_image_encodings = {
+      {"RGB_INT8", sensor_msgs::image_encodings::RGB8},
+      {"L_INT8", sensor_msgs::image_encodings::TYPE_8UC1}};
+  const auto pixel_format = supported_image_encodings.at(cam->ImageFormat());
+
+  // copy from simulation image to ROS msg
+  fillImage(this->image_msg_, pixel_format, cam->ImageHeight(),
+            cam->ImageWidth(), cam->ImageDepth() * cam->ImageWidth(),
+            reinterpret_cast<const void *>(cam->ImageData()));
+
+  // identify camera rendering
+  const std::map<std::string, rendering::CameraPtr> cameras = {
+      {COLOR_CAMERA_NAME, this->colorCam},
+      {IRED1_CAMERA_NAME, this->ired1Cam},
+      {IRED2_CAMERA_NAME, this->ired2Cam},
+  };
+
+  // publish to ROS
+  auto camera_info_msg =
+      cameraInfo(this->image_msg_, cameras.at(camera_id)->HFOV().Radian());
+  image_pub->publish(this->image_msg_, camera_info_msg);
+}
+
+// Referenced from gazebo_plugins
+// https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp#L302
+// Fill depth information
+bool GazeboRosRealsense::FillPointCloudHelper(sensor_msgs::PointCloud2 &point_cloud_msg,
+                                              uint32_t rows_arg, uint32_t cols_arg,
+                                              uint32_t step_arg, void *data_arg)
+{
+  sensor_msgs::PointCloud2Modifier pcd_modifier(point_cloud_msg);
+  pcd_modifier.setPointCloud2FieldsByString(2, "xyz", "rgb");
+  // convert to flat array shape, we need to reconvert later
+  pcd_modifier.resize(rows_arg * cols_arg);
+  point_cloud_msg.is_dense = true;
+
+  sensor_msgs::PointCloud2Iterator<float> iter_x(pointcloud_msg_, "x");
+  sensor_msgs::PointCloud2Iterator<float> iter_y(pointcloud_msg_, "y");
+  sensor_msgs::PointCloud2Iterator<float> iter_z(pointcloud_msg_, "z");
+  sensor_msgs::PointCloud2Iterator<uint8_t> iter_rgb(pointcloud_msg_, "rgb");
+
+  float *toCopyFrom = (float *)data_arg;
+  int index = 0;
+
+  double hfov = this->depthCam->HFOV().Radian();
+  double fl = ((double)this->depthCam->ImageWidth()) / (2.0 * tan(hfov / 2.0));
+
+  // convert depth to point cloud
+  for (uint32_t j = 0; j < rows_arg; j++)
+  {
+    double pAngle;
+    if (rows_arg > 1)
+      pAngle = atan2((double)j - 0.5 * (double)(rows_arg - 1), fl);
+    else
+      pAngle = 0.0;
+
+    for (uint32_t i = 0; i < cols_arg; i++, ++iter_x, ++iter_y, ++iter_z, ++iter_rgb)
+    {
+      double yAngle;
+      if (cols_arg > 1)
+        yAngle = atan2((double)i - 0.5 * (double)(cols_arg - 1), fl);
+      else
+        yAngle = 0.0;
+
+      double depth = toCopyFrom[index++];  // + 0.0*this->myParent->GetNearClip();
+
+      if (depth > pointCloudCutOff_ && depth < pointCloudCutOffMax_)
+      {
+        // in optical frame
+        // hardcoded rotation rpy(-M_PI/2, 0, -M_PI/2) is built-in
+        // to urdf, where the *_optical_frame should have above relative
+        // rotation from the physical camera *_frame
+        *iter_x = depth * tan(yAngle);
+        *iter_y = depth * tan(pAngle);
+        *iter_z = depth;
+      }
+      else  // point in the unseeable range
+      {
+        *iter_x = *iter_y = *iter_z = std::numeric_limits<float>::quiet_NaN();
+        point_cloud_msg.is_dense = false;
+      }
+
+      // put image color data for each point
+      uint8_t *image_src = (uint8_t *)(&(this->image_msg_.data[0]));
+      if (this->image_msg_.data.size() == rows_arg * cols_arg * 3)
+      {
+        // color
+        iter_rgb[0] = image_src[i * 3 + j * cols_arg * 3 + 0];
+        iter_rgb[1] = image_src[i * 3 + j * cols_arg * 3 + 1];
+        iter_rgb[2] = image_src[i * 3 + j * cols_arg * 3 + 2];
+      }
+      else if (this->image_msg_.data.size() == rows_arg * cols_arg)
+      {
+        // mono (or bayer?  @todo; fix for bayer)
+        iter_rgb[0] = image_src[i + j * cols_arg];
+        iter_rgb[1] = image_src[i + j * cols_arg];
+        iter_rgb[2] = image_src[i + j * cols_arg];
+      }
+      else
+      {
+        // no image
+        iter_rgb[0] = 0;
+        iter_rgb[1] = 0;
+        iter_rgb[2] = 0;
+      }
+    }
+  }
+
+  // reconvert to original height and width after the flat reshape
+  point_cloud_msg.height = rows_arg;
+  point_cloud_msg.width = cols_arg;
+  point_cloud_msg.row_step = point_cloud_msg.point_step * point_cloud_msg.width;
+
+  return true;
+}
+
+void GazeboRosRealsense::OnNewDepthFrame() {
+  // get current time
+  common::Time current_time = this->world->SimTime();
+
+  RealSensePlugin::OnNewDepthFrame();
+
+  // copy data into image
+  this->depth_msg_.header.frame_id =
+      this->cameraParamsMap_[DEPTH_CAMERA_NAME].optical_frame;
+  ;
+  this->depth_msg_.header.stamp.sec = current_time.sec;
+  this->depth_msg_.header.stamp.nsec = current_time.nsec;
+
+  // set image encoding
+  std::string pixel_format = sensor_msgs::image_encodings::TYPE_16UC1;
+
+  // copy from simulation image to ROS msg
+  fillImage(this->depth_msg_, pixel_format, this->depthCam->ImageHeight(),
+            this->depthCam->ImageWidth(), 2 * this->depthCam->ImageWidth(),
+            reinterpret_cast<const void *>(this->depthMap.data()));
+
+  // publish to ROS
+  auto depth_info_msg =
+      cameraInfo(this->depth_msg_, this->depthCam->HFOV().Radian());
+  this->depth_pub_.publish(this->depth_msg_, depth_info_msg);
+
+  if (pointCloud_ && this->pointcloud_pub_.getNumSubscribers() > 0)
+  {
+    this->pointcloud_msg_.header = this->depth_msg_.header;
+    this->pointcloud_msg_.width = this->depthCam->ImageWidth();
+    this->pointcloud_msg_.height = this->depthCam->ImageHeight();
+    this->pointcloud_msg_.row_step =
+        this->pointcloud_msg_.point_step * this->depthCam->ImageWidth();
+    FillPointCloudHelper(this->pointcloud_msg_, this->depthCam->ImageHeight(),
+                         this->depthCam->ImageWidth(), 2 * this->depthCam->ImageWidth(),
+                         (void *)this->depthCam->DepthData());
+    this->pointcloud_pub_.publish(this->pointcloud_msg_);
+  }
+}
+}
+
+namespace {
+std::string extractCameraName(const std::string &name) {
+  if (name.find(COLOR_CAMERA_NAME) != std::string::npos)
+    return COLOR_CAMERA_NAME;
+  if (name.find(IRED1_CAMERA_NAME) != std::string::npos)
+    return IRED1_CAMERA_NAME;
+  if (name.find(IRED2_CAMERA_NAME) != std::string::npos)
+    return IRED2_CAMERA_NAME;
+
+  ROS_ERROR("Unknown camera name");
+  return COLOR_CAMERA_NAME;
+}
+
+sensor_msgs::CameraInfo cameraInfo(const sensor_msgs::Image &image,
+                                   float horizontal_fov) {
+  sensor_msgs::CameraInfo info_msg;
+
+  info_msg.header = image.header;
+  info_msg.distortion_model = "plumb_bob";
+  info_msg.height = image.height;
+  info_msg.width = image.width;
+
+  float focal = 0.5 * image.width / tan(0.5 * horizontal_fov);
+
+  info_msg.K[0] = focal;
+  info_msg.K[4] = focal;
+  info_msg.K[2] = info_msg.width * 0.5;
+  info_msg.K[5] = info_msg.height * 0.5;
+  info_msg.K[8] = 1.;
+
+  info_msg.P[0] = info_msg.K[0];
+  info_msg.P[5] = info_msg.K[4];
+  info_msg.P[2] = info_msg.K[2];
+  info_msg.P[6] = info_msg.K[5];
+  info_msg.P[10] = info_msg.K[8];
+
+  //    info_msg.roi.do_rectify = true;
+
+  return info_msg;
+}
+}


### PR DESCRIPTION
Used code from https://github.com/pal-robotics/realsense_gazebo_plugin and https://github.com/pal-robotics-forks/realsense/tree/upstream/realsense2_description/urdf to simulate the Realsense on Gazebo.

To test it you need to launch the simulation with disable_3d_sensor:=false, since by default it is set to 'true' to reduce the computational load.