### PR TITLE
Additions to MaplessNavigation

### DIFF
--- a/vizzy_navigation/include/mapless_nav/mapless_navigator.hpp
+++ b/vizzy_navigation/include/mapless_nav/mapless_navigator.hpp
@@ -28,6 +28,7 @@
 #include <actionlib/server/simple_action_server.h>
 #include <move_base_msgs/MoveBaseAction.h>
 
+#include <std_srvs/Empty.h>
 
 
 class MaplessNavigator
@@ -46,6 +47,8 @@ private:
 
     dynamic_reconfigure::Server<vizzy_navigation::MaplessConfig> server_;
     dynamic_reconfigure::Server<vizzy_navigation::MaplessConfig>::CallbackType f_;
+
+    ros::ServiceServer clear_costmaps_srv_;
 
     std::string common_frame_;
     geometry_msgs::PoseStamped robot_pose_;
@@ -80,7 +83,7 @@ public:
     MaplessNavigator(ros::NodeHandle &nh);
 
     void doControlBase();
-
+    bool clearCostmapsService(std_srvs::Empty::Request &req, std_srvs::Empty::Response &resp);
     void disableControl();
     void enableControl();
 

--- a/vizzy_navigation/include/mapless_nav/obstacle_avoidance.hpp
+++ b/vizzy_navigation/include/mapless_nav/obstacle_avoidance.hpp
@@ -61,6 +61,11 @@ public:
 
 	bool rStuck = false;
 
+	// Internal Storage
+	costmap_2d::Costmap2DROS* mLocalMap;
+	costmap_2d::Costmap2D* mCostmap;
+	double mRasterSize;
+
 private:
 	// Internal Methods
 	/**
@@ -108,10 +113,6 @@ private:
 	ros::NodeHandle nh;
 	ros::NodeHandle nPriv;
 
-	// Internal Storage
-	costmap_2d::Costmap2DROS* mLocalMap;
-	costmap_2d::Costmap2D* mCostmap;
-	double mRasterSize;
 	
 	ros::Publisher mTrajectoryPublisher;
 	ros::Publisher mPlanPublisher;

--- a/vizzy_navigation/param/costmap.yaml
+++ b/vizzy_navigation/param/costmap.yaml
@@ -31,7 +31,8 @@ inflater:
 
 laserobstacles:
   observation_sources: scan
-  scan: {data_type: LaserScan, topic: scan_filtered, marking: true, clearing: true}
+  scan: {data_type: LaserScan, topic: scan_filtered, marking: true, clearing: true, inf_is_valid: true}
+  observation_persistence: 0.0
   obstacle_range: 25.0
   raytrace_range: 30.0
   marking: true
@@ -39,7 +40,8 @@ laserobstacles:
   
 laserobstaclesrear:
   observation_sources: scan_rear
-  scan_rear: {data_type: LaserScan, topic: scan_filtered_rear, marking: true, clearing: true}
+  scan_rear: {data_type: LaserScan, topic: scan_filtered_rear, marking: true, clearing: true, inf_is_valid: true}
+  observation_persistence: 0.0
   obstacle_range: 3.5
   raytrace_range: 4.0
   marking: true 

--- a/vizzy_navigation/param/costmap.yaml
+++ b/vizzy_navigation/param/costmap.yaml
@@ -46,7 +46,6 @@ laserobstaclesrear:
   clearing: true
 
 
-
 kinectobstacles:
   observation_sources: pointcloud_sensor_in pointcloud_sensor_clear
   pointcloud_sensor_in:
@@ -74,6 +73,12 @@ kinectobstacles:
     obstacle_range: 2.5
     raytrace_range: 4.0
 
+obstacle_static_map:
+  unknown_cost_value: -1
+  lethal_cost_threshold: 100
+  map_topic: /obst/map_obstacles
+
+
 #kinectobstacles_clear:
 #  observation_sources: pointcloud_sensor_clear
 #  pointcloud_sensor_clear:
@@ -90,6 +95,8 @@ kinectobstacles:
 #    raytrace_range: 2.5
 
 plugins:
+## Comment the next line when not using an obstacle static map
+ - {name: obstacle_static_map, type: "costmap_2d::StaticLayer"}
  - {name: laserobstacles, type: "costmap_2d::VoxelLayer"}
  - {name: laserobstaclesrear, type: "costmap_2d::VoxelLayer"}
 # - {name: kinectobstacles, type: "costmap_2d::VoxelLayer"}

--- a/vizzy_navigation/src/mapless_navigator.cpp
+++ b/vizzy_navigation/src/mapless_navigator.cpp
@@ -24,7 +24,20 @@ MaplessNavigator::MaplessNavigator(ros::NodeHandle &nh) : nh_(nh), nPriv_("~"), 
 	as_.registerPreemptCallback(boost::bind(&MaplessNavigator::actionPreemptCB, this));
 
 	as_.start();
+	
+	//advertise a service for clearing the costmaps (as in the move_base package)
+	clear_costmaps_srv_ = nPriv_.advertiseService("clear_costmaps", &MaplessNavigator::clearCostmapsService, this);
 
+
+}
+
+bool MaplessNavigator::clearCostmapsService(std_srvs::Empty::Request &req, std_srvs::Empty::Response &resp)
+{
+    //clear the costmaps
+    boost::unique_lock<costmap_2d::Costmap2D::mutex_t> lock_controller(*(obs_avoider_.mLocalMap->getCostmap()->getMutex()));
+    obs_avoider_.mLocalMap->resetLayers();
+
+    return true;
 }
 
 void MaplessNavigator::dynamic_rec_callback(vizzy_navigation::MaplessConfig &config, uint32_t level)


### PR DESCRIPTION
- Use static map information from an obstacles map to avoid dangerous areas (requires conventional mapping): comment/uncomment https://github.com/vislab-tecnico-lisboa/vizzy/blob/c1ababdb93f98d314a719e65ac9d2b93a893fed4/vizzy_navigation/param/costmap.yaml#L99 to disable/enable this feature. When no map is available we need to disable this feature.
-  MaplessNavigator now has a service to clear costmaps like move_base: rosservice call /MaplessNavigator/clear_costmaps "{}"
- Enabled "inf" laser readings to clear dynamic obstacles from costmaps of mapless navigation